### PR TITLE
Fix link ‘64bit (default)’ for ‘Pharo image’ in the section ‘Pharo standalone’ on the ‘Downloads’ page

### DIFF
--- a/site/download.md
+++ b/site/download.md
@@ -139,7 +139,7 @@ You can download the Pharo VM and image as separated packages.
 <li><i class="fa fa-windows"></I> Pharo stable VM for Windows: <a href="http://files.pharo.org/get-files/120/pharo-vm-Windows-x86_64-stable.zip">64bit (default)</a> | <a href="http://files.pharo.org/get-files/120/pharo-vm-Windows-X86-stable.zip">32bit</a></li>
 <li><i class="fa fa-apple"></I> Pharo stable VM for macOS: <a href="http://files.pharo.org/get-files/120/pharo-vm-Darwin-x86_64-stable.zip">Intel 64bit</a> | <a href="http://files.pharo.org/get-files/120/pharo-vm-Darwin-arm64-stable.zip">Apple Silicon (default)</a></li>
 <li><i class="fa fa-linux"></I> Pharo stable VM for Linux: <a href="http://files.pharo.org/get-files/120/pharo-vm-Linux-x86_64-stable.zip">64bit (default)</a> | <a href="https://files.pharo.org/get-files/100/pharo-linux-stable.zip">32bit</a>  (WARNING: This linux builds were made for Debian based distributions, in any other case, we recommend to use the OBS based package).</li>
-<li>Pharo image: <a href="https://files.pharo.org/get-files/120/pharo64.zip">64bit (default)</a> | <a href="http://files.pharo.org/image/100/stable-32.zip">32bit</a></li>
+<li>Pharo image: <a href="https://files.pharo.org/image/120/latest-64.zip">64bit (default)</a> | <a href="http://files.pharo.org/image/100/stable-32.zip">32bit</a></li>
 </ul>
 
   </div>


### PR DESCRIPTION
This pull request fixes the link ‘64bit (default)’ for ‘Pharo image’ in the section ‘Pharo standalone’ on the ‘Downloads’ page. The current URL leads to a ‘Not Found’ error, the new one is the same one as used in the [Pharo Launcher ‘sources.list’](https://github.com/pharo-project/pharo-launcher/blob/8eaea508a07c1a3e56e06a05787450720384dd63/sources.list#L26-L30).