### PR TITLE
[FIX] : fixed the link on the community page

### DIFF
--- a/site/community.md
+++ b/site/community.md
@@ -50,7 +50,7 @@ In addition, there is a more technical blog about the pharo development:
 
 ## Students/Newcomers: SummerSchool and Google Summer of Code
 
-[https://newcomers.pharo.org] has resources for Students and new users.
+[https://newcomers.pharo.org](https://newcomers.pharo.org) has resources for Students and new users.
 
 
 ## Teachers and Research Groups


### PR DESCRIPTION
On the [community page](https://www.pharo.org/community) the md syntax of the link was incorrect that resulted the link to behave as plain text, which i corrected.

<img width="902" alt="Screenshot 2025-03-13 at 6 36 15 PM" src="https://github.com/user-attachments/assets/5ed05ed1-348d-4543-9c6f-bb615bac17ec" />
